### PR TITLE
Add Pin handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ with open('data', 'rb') as f:
 print(z)  # z might be a wide range of Python objects
 ```
 The protocol is self describing even when extended. The file
-`umsgpack/umsgpack_ext.py` extends support to `complex`, `tuple` and `set`
-built-in types. Provided that file exists on the target, the code above will
-work even if the data includes such objects. Extension can be provided in a way
-that is transparent to the application.
+`umsgpack/umsgpack_ext.py` extends support to `complex`, `tuple`, `set` and
+`Pin` built-in types. Provided that file exists on the target, the code above
+will work even if the data includes such objects. Extension can be provided in
+a way that is transparent to the application.
 
 This document focuses on usage with MicroPython and skips most of the detail on
 how MessagePack works. The
@@ -60,6 +60,9 @@ following:
  if it is encoded as a `tuple` it will be decoded as one.
  * `complex`
  * `set`
+ * `Pin` Provides a mean for handling pin references. Pin configuration and
+ status is not stored/sent; physical pin is never initialized when information
+ is received.
 
 
 
@@ -110,8 +113,8 @@ In particular, it supports the new binary, UTF-8 string and application-defined
 ext types. As stated above, timestamps are unsupported.
 
 The repository includes `umsgpack/umsgpack_ext.py` which optionally extends the
-library to support Python `set`, `complex` and `tuple` objects. The aim is to
-show how this can easily be extended to include further types.
+library to support Python `set`, `complex`, `tuple` and `Pin` objects. The aim is
+to show how this can easily be extended to include further types.
 
 This MicroPython version uses various techniques to minimise RAM use including
 "lazy imports": a module is only imported on first usage. For example an
@@ -189,10 +192,11 @@ arg.
 
 # 5. Extension module
 
-The `umsgpack_ext` module extends `umsgpack` to support `complex`, `set` and
-`tuple` types, but its design facilitates adding further Python built-in types
-or types supported by other libraries. Support is entirely transparent to the
-application: the added types behave in the same way as native types.
+The `umsgpack_ext` module extends `umsgpack` to support `complex`, `set`,
+`tuple` and `Pin` types, but its design facilitates adding further Python
+built-in types or types supported by other libraries. Support is entirely
+transparent to the application: the added types behave in the same way as
+native types.
 
 The following examples may be pasted at the REPL:
 ```python
@@ -207,8 +211,19 @@ with open('data', 'rb') as f:
     z = umsgpack.load(f)
 print(z)  # z is complex
 ```
- The file `umsgpack_ext.py` may be found in the `umsgpack` directory. To extend
- it to support additional types, see
+
+`Pin` handling requires a further configuration before being used, because
+class `Pin`'s first argument `id` is specific to the Micropython port. User
+has to set the correct value for `PIN_TYPE` with `umsgpack.PIN_TYPE = x`,
+in `umsgpack_ext.py` or somewhere else where the extension module is used.
+Valid values:
+ * `0` no Pin handling
+ * `1` integer, i.e., `Pin(0)`
+ * `2` string, i.e., `Pin('LED1')`
+ * `3` tuple, i.e., `Pin(('GPIO_1', 1))`
+
+The file `umsgpack_ext.py` may be found in the `umsgpack` directory. To extend
+it to support additional types, see
 [section 11](./README.md#11-notes-on-the-extension-module).
 
 # 6. Serialisable user classes

--- a/machine.py
+++ b/machine.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Mockup class for machine Pin
+
+class Pin:
+    ID_TYPE = 0
+
+    def __init__(self, id):
+        self._port = None
+        self._pin = None
+        if self.ID_TYPE == 0:
+            raise NotImplementedError
+        elif self.ID_TYPE == 1 and isinstance(id, int):
+            self._pin = id
+        elif self.ID_TYPE == 2 and isinstance(id, str):
+            self._pin = id
+        elif self.ID_TYPE == 3 and isinstance(id, tuple) and\
+                isinstance(id[0], str) and isinstance(id[1], int):
+            self._port = id[0]
+            self._pin = id[1]
+        else:
+            raise TypeError
+
+    def __eq__(self, other):
+        return self._port == other._port and\
+               self._pin == other._pin
+
+    def name(self):
+        return self._pin
+
+    def port(self):
+        return self._port
+
+    def pin(self):
+        return self._pin

--- a/run_test_suite
+++ b/run_test_suite
@@ -1,5 +1,15 @@
 #! /bin/bash
 
+[[ $MP ]] || MP=micropython
+
+function run {
+        echo "-> Run '$@'"
+        "$@"
+}
+
 mv umsgpack/umsgpack_ext.py umsgpack/umsgpack_ext.tmp
-python3 test_umsgpack.py
+run python3 test_umsgpack.py
 mv umsgpack/umsgpack_ext.tmp umsgpack/umsgpack_ext.py
+
+run python3 test_umsgpack_ext.py
+run $MP test_umsgpack_ext.py

--- a/test_umsgpack_ext.py
+++ b/test_umsgpack_ext.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Run test_umsgpack.py with Python3 to test the correctness of umsgpack_ext.py:
+#
+#   $ python3 test_umsgpack_ext.py
+#   $ micropython test_umsgpack_ext.py
+
+import unittest
+
+import umsgpack
+
+def roundtrip (obj):
+    return umsgpack.loads(umsgpack.dumps(obj))
+
+
+class TestUmsgpackExt(unittest.TestCase):
+
+    def test_complex(self):
+        obj = complex(1, 2)
+        ext = umsgpack_ext.Complex(obj)
+        self.assertEqual(str(ext), "Complex((1+2j))")
+        self.assertEqual(obj, roundtrip(obj))
+
+    def test_set(self):
+        obj = set([1, 2, 3])
+        ext = umsgpack_ext.Set(obj)
+        self.assertEqual(str(ext), "Set({1, 2, 3})")
+        self.assertEqual(obj, roundtrip(obj))
+
+    def test_tuple(self):
+        obj = tuple([1, 2, 3])
+        ext = umsgpack_ext.Tuple(obj)
+        self.assertEqual(str(ext), "Tuple((1, 2, 3))")
+        self.assertEqual(obj, roundtrip(obj))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_umsgpack_ext.py
+++ b/test_umsgpack_ext.py
@@ -5,8 +5,10 @@
 #   $ micropython test_umsgpack_ext.py
 
 import unittest
+from machine import Pin
 
 import umsgpack
+from umsgpack import umsgpack_ext
 
 def roundtrip (obj):
     return umsgpack.loads(umsgpack.dumps(obj))
@@ -32,6 +34,26 @@ class TestUmsgpackExt(unittest.TestCase):
         self.assertEqual(str(ext), "Tuple((1, 2, 3))")
         self.assertEqual(obj, roundtrip(obj))
 
+    def test_pin_int(self):
+        umsgpack.PIN_TYPE = Pin.ID_TYPE = 1
+        obj = Pin(0)
+        ext = umsgpack_ext.PinInt(obj)
+        self.assertEqual(str(ext), "Pin(0)")
+        self.assertEqual(obj, roundtrip(obj))
+
+    def test_pin_str(self):
+        umsgpack.PIN_TYPE = Pin.ID_TYPE = 2
+        obj = Pin("LED1")
+        ext = umsgpack_ext.PinStr(obj)
+        self.assertEqual(str(ext), "Pin('LED1')")
+        self.assertEqual(obj, roundtrip(obj))
+
+    def test_pin_tuple(self):
+        umsgpack.PIN_TYPE = Pin.ID_TYPE = 3
+        obj = Pin(("GPIO_1", 1))
+        ext = umsgpack_ext.PinTuple(obj)
+        self.assertEqual(str(ext), "Pin(('GPIO_1', 1))")
+        self.assertEqual(obj, roundtrip(obj))
 
 if __name__ == '__main__':
     unittest.main()

--- a/umsgpack/umsgpack_ext.py
+++ b/umsgpack/umsgpack_ext.py
@@ -12,9 +12,27 @@
 import umsgpack
 import struct
 
+try:
+    from machine import Pin
+except ImportError:
+    pass
+
+# Inject Pin's id type for easier configuration.
+#
+# Class Pin's first argument `id` is specific to the Micropython port. Set the
+# correct value with `umsgpack.PIN_TYPE = x`, here or somewhere else where this
+# module is used.
+#
+# Valid values:
+# * `0` no Pin handling
+# * `1` integer, i.e., `Pin(0)`
+# * `2` string, i.e., `Pin('LED1')`
+# * `3` tuple, i.e., `Pin(('GPIO_1', 1))`
+umsgpack.PIN_TYPE = 0
+
 # Entries in mpext are required where types are to be handled without declaring
 # an ext_serializable class in the application. This example enables complex,
-# tuple and set types to be packed as if they were native to umsgpack.
+# tuple, set and Pin types to be packed as if they were native to umsgpack.
 # Options (kwargs to dump and dumps) may be passed to constructor including new
 # type-specific options
 def mpext(obj, options):
@@ -24,6 +42,15 @@ def mpext(obj, options):
         return Set(obj)
     if isinstance(obj, tuple):
         return Tuple(obj)
+    if umsgpack.PIN_TYPE and isinstance(obj, Pin):
+        if umsgpack.PIN_TYPE == 1:
+            return PinInt(obj)
+        elif umsgpack.PIN_TYPE == 2:
+            return PinStr(obj)
+        elif umsgpack.PIN_TYPE == 3:
+            return PinTuple(obj)
+        else:
+            raise umsgpack.UnsupportedTypeException
     return obj
 
 @umsgpack.ext_serializable(0x50)
@@ -70,3 +97,52 @@ class Tuple:
     @staticmethod
     def unpackb(data):
         return tuple(umsgpack.loads(data))
+
+@umsgpack.ext_serializable(0x53)
+class PinInt:
+    def __init__(self, p):
+        self.pin = p.pin()
+
+    def __str__(self):
+        return "Pin({})".format(self.pin)
+
+    def packb(self):
+        return self.pin.to_bytes(1, "big")
+
+    @staticmethod
+    def unpackb(data):
+        return Pin(int.from_bytes(data, "big"))
+
+@umsgpack.ext_serializable(0x54)
+class PinStr:
+    def __init__(self, p):
+        self.name = p.name()
+
+    def __str__(self):
+        return "Pin('{}')".format(self.name)
+
+    def packb(self):
+        return self.name.encode()
+
+    @staticmethod
+    def unpackb(data):
+        return Pin(data.decode())
+
+@umsgpack.ext_serializable(0x55)
+class PinTuple:
+    def __init__(self, p):
+        self.port = p.port()
+        self.pin = p.pin()
+
+    def __str__(self):
+        return "Pin(('{}', {}))".format(self.port, self.pin)
+
+    def packb(self):
+        lp = len(self.port)
+        return struct.pack("B{}s".format(lp), self.pin, self.port.encode())
+
+    @staticmethod
+    def unpackb(data):
+        lp = len(data) - 1
+        pin, port = struct.unpack("B{}s".format(lp), data)
+        return Pin((port.decode(), pin))


### PR DESCRIPTION
I propose to add `Pin` handling because it is a native type in Micropython. Note that I couldn't test `PinInt` and `PinTuple` myself because of lack of hardware.

I also added a test file for `umsgpack_ext.py` for checking my implementation. I believe it's also good for keeping `umsgpack_ext.py` under control.