### PR TITLE
Async-related changes, mostly to foster communications between a (full python3) host and one or more Micropython-based microcontrollers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,13 @@ there is a practical use case for `ext_handlers`: an easier way is to use
  `dict`. (default `False`).
  3. `use_tuple` (bool): unpacks arrays into tuples, instead of lists (default
  `False`). The extension module (if used) makes this redundant.
- 4. `ext_handlers` a dictionary of Ext handlers, mapping integer Ext type to a
+ 4. `ext_handlers`: a dictionary of Ext handlers, mapping integer Ext type to a
  callable that unpacks an instance of Ext into an object. See
  [section 8](./README.md#8-ext-handlers).
-
+ 5. `observer` (aload only): an object with an update() method, which is
+ called with the results of each readexactly(n) call. This could be used, for
+ example, to calculate a CRC value on the received message data.
+ 
 Work is in progress to make `dict` instances ordered by default, so option 3
 may become pointless. The `umsgpack_ext` module enables tuples to be encoded in
 a different format to lists which is more flexible than the global `use_tuple`

--- a/README.md
+++ b/README.md
@@ -313,8 +313,9 @@ async def receiver():
         res = await umsgpack.aload(sreader)
         print('Recieved', res)
 ```
-The demo `asyntest.py` runs on a Pyboard with pins X1 and X2 linked. The code
-includes notes regarding RAM overhead.
+The demo `asyntest.py` runs on a Pyboard (or Pi Pico) with pins X1 and X2 linked. The code includes notes regarding RAM overhead.
+
+The demo `asyntest_py3_serial.py` is similar, but meant to run on a computer with full python3.
 
 # 8. Ext Handlers
 
@@ -441,7 +442,7 @@ Python2 code removed.
 Compatibility mode removed.  
 Timestamps removed.  
 Converted to Python package with lazy import to save RAM.  
-Provide uasyncio StreamReader support.  
+Provide asyncio StreamReader support.
 Exported functions now match ujson: dump, dumps, load, loads (only).  
 Many functions refactored to save bytes, e.g. replacing the function dispatch
 table with code.  

--- a/README.md
+++ b/README.md
@@ -316,6 +316,17 @@ async def receiver():
         res = await umsgpack.aload(sreader)
         print('Recieved', res)
 ```
+
+Alternatively, instead of using the `aload()` method, an `aloader` class can be
+instantiated and utilized. For example:
+```python
+async def receiver():
+    uart_aloader = umsgpack.aloader(asyncio.StreamReader(uart))
+    while True:
+        res = await uart_aloader.load()
+        print('Received', res)
+```
+
 The demo `asyntest.py` runs on a Pyboard (or Pi Pico) with pins X1 and X2 linked. The code includes notes regarding RAM overhead.
 
 The demo `asyntest_py3_serial.py` is similar, but meant to run on a computer with full python3.

--- a/asyntest.py
+++ b/asyntest.py
@@ -9,12 +9,15 @@
 # This compares with 5312 bytes for a similar script sending plain text.
 # The MessagePack overhead is thus 13,248 bytes (12.9KiB).
 
-import uasyncio as asyncio
+import asyncio
 import umsgpack
-from machine import UART
+from machine import UART, Pin
 import gc
 
-uart = UART(4, 9600)
+try:
+    uart = UART(4, 9600)  # Pyboard (link pins X1 and X2)
+except ValueError:
+    uart = UART(0, baudrate=9600, tx=Pin(0), rx=Pin(1))  # Pi Pico (link pins 0 and 1)
 
 async def sender():
     swriter = asyncio.StreamWriter(uart, {})

--- a/asyntest.py
+++ b/asyntest.py
@@ -31,10 +31,15 @@ async def sender():
         await asyncio.sleep(5)
         obj[0] += 1
 
+class stream_observer:
+    def update(self, data: bytes) -> None:
+        print(f'{data}')
+
 async def receiver():
+    recv_observer = stream_observer()
     sreader = asyncio.StreamReader(uart)
     while True:
-        res = await umsgpack.aload(sreader)
+        res = await umsgpack.aload(sreader, observer=recv_observer)
         print('Recieved', res)
 
 async def main():

--- a/asyntest.py
+++ b/asyntest.py
@@ -1,23 +1,29 @@
 # asyntest.py Test/demo of asychronous use of MessagePack
 
-# Configured for a Pyboard. Link pins X1 and X2.
-
 # Copyright (c) 2021 Peter Hinch Released under the MIT License see LICENSE
 
-# Free RAM after reset 101504 bytes. Free RAM while running 82944 bytes
-# Usage 18560 bytes i.e. ~18.1KiB
-# This compares with 5312 bytes for a similar script sending plain text.
-# The MessagePack overhead is thus 13,248 bytes (12.9KiB).
+# From testing on a pyboard:
+#   Free RAM after reset 101504 bytes. Free RAM while running 82944 bytes
+#   Usage 18560 bytes i.e. ~18.1KiB
+#   This compares with 5312 bytes for a similar script sending plain text.
+#   The MessagePack overhead is thus 13,248 bytes (12.9KiB).
 
+from sys import platform
 import asyncio
 import umsgpack
 from machine import UART, Pin
 import gc
 
-try:
+
+if platform == "pyboard":
     uart = UART(4, 9600)  # Pyboard (link pins X1 and X2)
-except ValueError:
+elif platform == "rp2":
     uart = UART(0, baudrate=9600, tx=Pin(0), rx=Pin(1))  # Pi Pico (link pins 0 and 1)
+elif platform == "esp32":
+    uart = UART(2, baudrate=9600, tx=17, rx=16)  # Adafruit Huzzah32 (link pins TX and RX)
+else:
+    raise OSError(f"Unknown platform {platform}")
+
 
 async def sender():
     swriter = asyncio.StreamWriter(uart, {})

--- a/asyntest.py
+++ b/asyntest.py
@@ -36,15 +36,22 @@ class stream_observer:
         print(f'{data}')
 
 async def receiver():
-    recv_observer = stream_observer()
     sreader = asyncio.StreamReader(uart)
+    recv_observer = stream_observer()
     while True:
         res = await umsgpack.aload(sreader, observer=recv_observer)
         print('Recieved', res)
 
+async def receiver_using_aloader():
+    uart_aloader = umsgpack.aloader(asyncio.StreamReader(uart), observer=stream_observer())
+    while True:
+        res = await uart_aloader.load()
+        print('Received (aloader):', res)
+
 async def main():
     asyncio.create_task(sender())
-    asyncio.create_task(receiver())
+    # asyncio.create_task(receiver())
+    asyncio.create_task(receiver_using_aloader())
     while True:
         gc.collect()
         print('mem free', gc.mem_free())

--- a/asyntest_py3_serial.py
+++ b/asyntest_py3_serial.py
@@ -19,10 +19,15 @@ async def sender(swriter):
         await asyncio.sleep(5)
         obj[0] += 1
 
+class stream_observer:
+    def update(self, data: bytes) -> None:
+        print(f'data: {data}')
+
 async def receiver(sreader):
+    recv_observer = stream_observer()
     while True:
-        res = await umsgpack.aload(sreader)
-        print('Recieved', res)
+        res = await umsgpack.aload(sreader, observer=recv_observer)
+        print('Received', res)
 
 async def main():
     reader, writer = await serial_asyncio.open_serial_connection(url='/dev/ttyUSB0', baudrate=9600)

--- a/asyntest_py3_serial.py
+++ b/asyntest_py3_serial.py
@@ -21,18 +21,25 @@ async def sender(swriter):
 
 class stream_observer:
     def update(self, data: bytes) -> None:
-        print(f'data: {data}')
+        print(f'{data}')
 
 async def receiver(sreader):
     recv_observer = stream_observer()
     while True:
         res = await umsgpack.aload(sreader, observer=recv_observer)
-        print('Received', res)
+        print('Received:', res)
+
+async def receiver_using_aloader(sreader):
+    uart_aloader = umsgpack.aloader(sreader, observer=stream_observer())
+    while True:
+        res = await uart_aloader.load()
+        print('Received (aloader):', res)
 
 async def main():
     reader, writer = await serial_asyncio.open_serial_connection(url='/dev/ttyUSB0', baudrate=9600)
     asyncio.create_task(sender(writer))
-    asyncio.create_task(receiver(reader))
+    # asyncio.create_task(receiver(reader))
+    asyncio.create_task(receiver_using_aloader(reader))
     while True:
         print('running...')
         await asyncio.sleep(20)

--- a/asyntest_py3_serial.py
+++ b/asyntest_py3_serial.py
@@ -1,0 +1,41 @@
+# asyntest_py3_serial.py Test/demo of asychronous use of MessagePack under full python3 with pyserial
+
+# Configured for pyserial. Link RX and TX pins.
+
+# Copyright (c) 2024 Peter Hinch Released under the MIT License see LICENSE
+
+import asyncio
+import umsgpack
+import serial_asyncio
+
+async def sender(swriter):
+    obj = [1, True, False, 0xffffffff, {u"foo": b"\x80\x01\x02", \
+                  u"bar": [1,2,3, {u"a": [1,2,3,{}]}]}, -1, 2.12345]
+
+    while True:
+        s = umsgpack.dumps(obj)
+        swriter.write(s)
+        await swriter.drain()
+        await asyncio.sleep(5)
+        obj[0] += 1
+
+async def receiver(sreader):
+    while True:
+        res = await umsgpack.aload(sreader)
+        print('Recieved', res)
+
+async def main():
+    reader, writer = await serial_asyncio.open_serial_connection(url='/dev/ttyUSB0', baudrate=9600)
+    asyncio.create_task(sender(writer))
+    asyncio.create_task(receiver(reader))
+    while True:
+        print('running...')
+        await asyncio.sleep(20)
+
+def test():
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print('Interrupted')
+
+test()

--- a/umsgpack/__init__.py
+++ b/umsgpack/__init__.py
@@ -26,7 +26,7 @@
 # Method of detecting platform's float size changed.
 # Version reset to (0.1.0).
 
-__version__ = (0, 1, 1)
+__version__ = (0, 1, 2)
 
 
 ##############################################################################

--- a/umsgpack/__init__.py
+++ b/umsgpack/__init__.py
@@ -17,7 +17,7 @@
 # Compatibility mode removed.
 # Timestamps removed.
 # Converted to Python package with lazy import to save RAM.
-# Provide uasyncio StreamReader support.
+# Provide asyncio StreamReader support.
 # Exported functions now match ujson: dump, dumps, load, loads (only).
 # Many functions refactored to save bytes, especially replace function
 # dispatch table with code.
@@ -350,7 +350,7 @@ async def aload(fp, **options):
     Deserialize MessagePack bytes from a StreamReader into a Python object.
 
     Args:
-        fp: a uasyncio StreamReader object
+        fp: a asyncio StreamReader object
 
     Kwargs:
         ext_handlers (dict): dictionary of Ext handlers, mapping integer Ext

--- a/umsgpack/as_load.py
+++ b/umsgpack/as_load.py
@@ -21,12 +21,20 @@ def _fail():  # Debug code should never be called.
     raise Exception('Logic error')
 
 
-async def _re0(s, fp, n):
+async def _re(fp, n, options):
     d = await fp.readexactly(n)
+    observer = options.get("observer")
+    if observer:
+        observer.update(d)
+    return d
+
+
+async def _re0(s, fp, n, options):
+    d = await _re(fp, n, options)
     return struct.unpack(s, d)[0]
 
 
-async def _unpack_integer(code, fp):
+async def _unpack_integer(code, fp, options):
     ic = ord(code)
     if (ic & 0xe0) == 0xe0:
         return struct.unpack("b", code)[0]
@@ -38,15 +46,15 @@ async def _unpack_integer(code, fp):
         s = "B >H>I>Qb >h>i>q"[off : off + 2]
     except IndexError:
         _fail()
-    return await _re0(s.strip(), fp, 1 << (ic & 3))
+    return await _re0(s.strip(), fp, 1 << (ic & 3), options)
 
 
-async def _unpack_float(code, fp):
+async def _unpack_float(code, fp, options):
     ic = ord(code)
     if ic == 0xca:
-        return await _re0(">f", fp, 4)
+        return await _re0(">f", fp, 4, options)
     if ic == 0xcb:
-        return await _re0(">d", fp, 8)
+        return await _re0(">d", fp, 8, options)
     _fail()
 
 
@@ -55,15 +63,15 @@ async def _unpack_string(code, fp, options):
     if (ic & 0xe0) == 0xa0:
         length = ic & ~0xe0
     elif ic == 0xd9:
-        length = await _re0("B", fp, 1)
+        length = await _re0("B", fp, 1, options)
     elif ic == 0xda:
-        length = await _re0(">H", fp, 2)
+        length = await _re0(">H", fp, 2, options)
     elif ic == 0xdb:
-        length = await _re0(">I", fp, 4)
+        length = await _re0(">I", fp, 4, options)
     else:
         _fail()
 
-    data = await fp.readexactly(length)
+    data = await _re(fp, length, options)
     try:
         return str(data, 'utf-8')  # Preferred MP way to decode
     except:  # MP does not have UnicodeDecodeError
@@ -72,18 +80,18 @@ async def _unpack_string(code, fp, options):
         raise InvalidStringException("unpacked string is invalid utf-8")
 
 
-async def _unpack_binary(code, fp):
+async def _unpack_binary(code, fp, options):
     ic = ord(code)
     if ic == 0xc4:
-        length = await _re0("B", fp, 1)
+        length = await _re0("B", fp, 1, options)
     elif ic == 0xc5:
-        length = await _re0(">H", fp, 2)
+        length = await _re0(">H", fp, 2, options)
     elif ic == 0xc6:
-        length = await _re0(">I", fp, 4)
+        length = await _re0(">I", fp, 4, options)
     else:
         _fail()
 
-    return await fp.readexactly(length)
+    return await _re(fp, length, options)
 
 
 async def _unpack_ext(code, fp, options):
@@ -92,16 +100,16 @@ async def _unpack_ext(code, fp, options):
     length = 0 if n < 0 else 1 << n
     if not length:
         if ic == 0xc7:
-            length = await _re0("B", fp, 1)
+            length = await _re0("B", fp, 1, options)
         elif ic == 0xc8:
-            length = await _re0(">H", fp, 2)
+            length = await _re0(">H", fp, 2, options)
         elif ic == 0xc9:
-            length = await _re0(">I", fp, 4)
+            length = await _re0(">I", fp, 4, options)
         else:
             _fail()
 
-    ext_type = await _re0("b", fp, 1)
-    ext_data = await fp.readexactly(length)
+    ext_type = await _re0("b", fp, 1, options)
+    ext_data = await _re(fp, length, options)
 
     # Create extension object
     ext = Ext(ext_type, ext_data)
@@ -124,9 +132,9 @@ async def _unpack_array(code, fp, options):
     if (ic & 0xf0) == 0x90:
         length = (ic & ~0xf0)
     elif ic == 0xdc:
-        length = await _re0(">H", fp, 2)
+        length = await _re0(">H", fp, 2, options)
     elif ic == 0xdd:
-        length = await _re0(">I", fp, 4)
+        length = await _re0(">I", fp, 4, options)
     else:
         _fail()
     l = []
@@ -146,9 +154,9 @@ async def _unpack_map(code, fp, options):
     if (ic & 0xf0) == 0x80:
         length = (ic & ~0xf0)
     elif ic == 0xde:
-        length = await _re0(">H", fp, 2)
+        length = await _re0(">H", fp, 2, options)
     elif ic == 0xdf:
-        length = await _re0(">I", fp, 4)
+        length = await _re0(">I", fp, 4, options)
     else:
         _fail()
 
@@ -182,10 +190,10 @@ async def _unpack_map(code, fp, options):
 
 
 async def _unpack(fp, options):
-    code = await fp.readexactly(1)
+    code = await _re(fp, 1, options)
     ic = ord(code)
     if (ic <= 0x7f) or (0xcc <= ic <= 0xd3) or (0xe0 <= ic <= 0xff):
-        return await _unpack_integer(code, fp)
+        return await _unpack_integer(code, fp, options)
     if ic <= 0xc9:
         if ic <= 0xc3:
             if ic <= 0x8f:
@@ -198,10 +206,10 @@ async def _unpack(fp, options):
                 raise ReservedCodeException("got reserved code: 0xc1")
             return (None, 0, False, True)[ic - 0xc0]
         if ic <= 0xc6:
-            return await _unpack_binary(code, fp)
+            return await _unpack_binary(code, fp, options)
         return _unpack_ext(code, fp, options)
     if ic <= 0xcb:
-        return await _unpack_float(code, fp)
+        return await _unpack_float(code, fp, options)
     if ic <= 0xd8:
         return await _unpack_ext(code, fp, options)
     if ic <= 0xdb:

--- a/umsgpack/as_load.py
+++ b/umsgpack/as_load.py
@@ -8,8 +8,6 @@
 
 import struct
 import collections
-import io
-from asyncio import StreamReader
 from . import *
 try:
     from . import umsgpack_ext
@@ -127,6 +125,7 @@ async def _unpack_ext(code, fp, options):
 
     return ext
 
+
 async def _unpack_array(code, fp, options):
     ic = ord(code)
     if (ic & 0xf0) == 0x90:
@@ -217,6 +216,7 @@ async def _unpack(fp, options):
     if ic <= 0xdd:
         return await _unpack_array(code, fp, options)
     return await _unpack_map(code, fp, options)
+
 
 # Interface to __init__.py
 

--- a/umsgpack/as_load.py
+++ b/umsgpack/as_load.py
@@ -9,7 +9,7 @@
 import struct
 import collections
 import io
-from uasyncio import StreamReader
+from asyncio import StreamReader
 from . import *
 try:
     from . import umsgpack_ext

--- a/umsgpack/as_load.py
+++ b/umsgpack/as_load.py
@@ -17,9 +17,14 @@ except ImportError:
     pass
 
 
+def _fail():  # Debug code should never be called.
+    raise Exception('Logic error')
+
+
 async def _re0(s, fp, n):
     d = await fp.readexactly(n)
     return struct.unpack(s, d)[0]
+
 
 async def _unpack_integer(code, fp):
     ic = ord(code)

--- a/umsgpack/as_loader.py
+++ b/umsgpack/as_loader.py
@@ -1,0 +1,219 @@
+# as_loader.py Defines the aloader class, which performs lightweight
+#              asynchronous MessagePack deserialization.
+#              It's the same deserialization logic as what's in as_load.py, but
+#              using an object-oriented implementation.
+
+# Copyright (c) 2024 Peter Hinch
+
+import struct
+import collections
+from . import *
+try:
+    from . import umsgpack_ext
+except ImportError:
+    pass
+
+
+class aloader:
+    """Deserialize MessagePack bytes from a StreamReader into a Python object.
+    """
+    def __init__(self, fp, options):
+        self.fp = fp
+        self.allow_invalid_utf8 = options.get("allow_invalid_utf8")
+        self.use_ordered_dict = options.get("use_ordered_dict")
+        self.use_tuple = options.get("use_tuple")
+        self.ext_handlers = options.get("ext_handlers")
+        self.observer = options.get("observer")
+
+    @staticmethod
+    def _fail():  # Debug code should never be called.
+        raise Exception('Logic error')
+
+    async def _re(self, n):
+        d = await self.fp.readexactly(n)
+        if self.observer:
+            self.observer.update(d)
+        return d
+
+    async def _re0(self, s, n):
+        d = await self._re(n)
+        return struct.unpack(s, d)[0]
+
+    async def _unpack_integer(self, code):
+        ic = ord(code)
+        if (ic & 0xe0) == 0xe0:
+            return struct.unpack("b", code)[0]
+        if (ic & 0x80) == 0x00:
+            return struct.unpack("B", code)[0]
+        ic -= 0xcc
+        off = ic << 1
+        try:
+            s = "B >H>I>Qb >h>i>q"[off : off + 2]
+        except IndexError:
+            aloader._fail()
+        return await self._re0(s.strip(), 1 << (ic & 3))
+
+    async def _unpack_float(self, code):
+        ic = ord(code)
+        if ic == 0xca:
+            return await self._re0(">f", 4)
+        if ic == 0xcb:
+            return await self._re0(">d", 8)
+        aloader._fail()
+
+    async def _unpack_string(self, code):
+        ic = ord(code)
+        if (ic & 0xe0) == 0xa0:
+            length = ic & ~0xe0
+        elif ic == 0xd9:
+            length = await self._re0("B", 1)
+        elif ic == 0xda:
+            length = await self._re0(">H", 2)
+        elif ic == 0xdb:
+            length = await self._re0(">I", 4)
+        else:
+            aloader._fail()
+
+        data = await self._re(length)
+        try:
+            return str(data, 'utf-8')  # Preferred MP way to decode
+        except:  # MP does not have UnicodeDecodeError
+            if self.allow_invalid_utf8:
+                return data  # MP Remove InvalidString class: subclass of built-in class
+            raise InvalidStringException("unpacked string is invalid utf-8")
+
+    async def _unpack_binary(self, code):
+        ic = ord(code)
+        if ic == 0xc4:
+            length = await self._re0("B", 1)
+        elif ic == 0xc5:
+            length = await self._re0(">H", 2)
+        elif ic == 0xc6:
+            length = await self._re0(">I", 4)
+        else:
+            aloader._fail()
+
+        return await self._re(length)
+
+    async def _unpack_ext(self, code):
+        ic = ord(code)
+        n = b'\xd4\xd5\xd6\xd7\xd8'.find(code)
+        length = 0 if n < 0 else 1 << n
+        if not length:
+            if ic == 0xc7:
+                length = await self._re0("B", 1)
+            elif ic == 0xc8:
+                length = await self._re0(">H", 2)
+            elif ic == 0xc9:
+                length = await self._re0(">I", 4)
+            else:
+                aloader._fail()
+
+        ext_type = await self._re0("b", 1)
+        ext_data = await self._re(length)
+
+        # Create extension object
+        ext = Ext(ext_type, ext_data)
+
+        # Unpack with ext handler, if we have one
+        if self.ext_handlers and ext.type in self.ext_handlers:
+            return self.ext_handlers[ext.type](ext)
+        # Unpack with ext classes, if type is registered
+        if ext_type in _ext_type_to_class:  # bug?: should this instead be ext_type_to_class, from __init__.py ?
+            try:
+                return _ext_type_to_class[ext_type].unpackb(ext_data)
+            except AttributeError:
+                raise NotImplementedError("Ext class {:s} lacks unpackb()".format(repr(_ext_type_to_class[ext_type])))
+
+        return ext
+
+    async def _unpack_array(self, code):
+        ic = ord(code)
+        if (ic & 0xf0) == 0x90:
+            length = (ic & ~0xf0)
+        elif ic == 0xdc:
+            length = await self._re0(">H", 2)
+        elif ic == 0xdd:
+            length = await self._re0(">I", 4)
+        else:
+            aloader._fail()
+        l = []
+        for i in range(length):
+            l.append(await self._unpack())
+        return tuple(l) if self.use_tuple else l
+
+    @staticmethod
+    def _deep_list_to_tuple(obj):
+        if isinstance(obj, list):
+            return tuple([aloader._deep_list_to_tuple(e) for e in obj])
+        return obj
+
+    async def _unpack_map(self, code):
+        ic = ord(code)
+        if (ic & 0xf0) == 0x80:
+            length = (ic & ~0xf0)
+        elif ic == 0xde:
+            length = await self._re0(">H", 2)
+        elif ic == 0xdf:
+            length = await self._re0(">I", 4)
+        else:
+            aloader._fail()
+
+        d = {} if not self.use_ordered_dict else collections.OrderedDict()
+        for _ in range(length):
+            # Unpack key
+            k = await self._unpack()
+
+            if isinstance(k, list):
+                # Attempt to convert list into a hashable tuple
+                k = aloader._deep_list_to_tuple(k)
+            try:
+                hash(k)
+            except:
+                raise UnhashableKeyException(
+                    "unhashable key: \"{:s}\"".format(str(k)))
+            if k in d:
+                raise DuplicateKeyException(
+                    "duplicate key: \"{:s}\" ({:s})".format(str(k), str(type(k))))
+
+            # Unpack value
+            v = await self._unpack()
+
+            try:
+                d[k] = v
+            except TypeError:
+                raise UnhashableKeyException(
+                    "unhashable key: \"{:s}\"".format(str(k)))
+        return d
+
+    async def _unpack(self):
+        code = await self._re(1)
+        ic = ord(code)
+        if (ic <= 0x7f) or (0xcc <= ic <= 0xd3) or (0xe0 <= ic <= 0xff):
+            return await self._unpack_integer(code)
+        if ic <= 0xc9:
+            if ic <= 0xc3:
+                if ic <= 0x8f:
+                    return await self._unpack_map(code)
+                if ic <= 0x9f:
+                    return await self._unpack_array(code)
+                if ic <= 0xbf:
+                    return await self._unpack_string(code)
+                if ic == 0xc1:
+                    raise ReservedCodeException("got reserved code: 0xc1")
+                return (None, 0, False, True)[ic - 0xc0]
+            if ic <= 0xc6:
+                return await self._unpack_binary(code)
+            return self._unpack_ext(code)
+        if ic <= 0xcb:
+            return await self._unpack_float(code)
+        if ic <= 0xd8:
+            return await self._unpack_ext(code)
+        if ic <= 0xdb:
+            return await self._unpack_string(code)
+        if ic <= 0xdd:
+            return await self._unpack_array(code)
+        return await self._unpack_map(code)
+
+    async def load(self):
+        return await self._unpack()


### PR DESCRIPTION
- Changed uasyncio to asyncio.
  - Provided a new example, asyntest_py3_serial.py, to demonstrate running under full python3.
- Changed as_load.py.
  - Added missing _file() function.
  - Added 'observer' option for aload.
- Added as_loader.py.
  - New aloader class, which offers the same functionality as aload, but in a cleaner, objected-oriented manner.